### PR TITLE
Add the ability to specify the range/format of generated decimals

### DIFF
--- a/src/com/amazon/ion/benchmark/GeneratorOptions.java
+++ b/src/com/amazon/ion/benchmark/GeneratorOptions.java
@@ -1,0 +1,16 @@
+package com.amazon.ion.benchmark;
+
+import java.util.Map;
+
+public class GeneratorOptions {
+        
+    public static void excuteGenerator(Map<String, Object> optionsMap) throws Exception {
+            
+        String format = optionsMap.get("--format").toString().substring(1,optionsMap.get("--format").toString().length()-1);
+        String exp_range = optionsMap.get("--decimal-exponent-range").toString() ;
+        String coeffi_digits= optionsMap.get("--decimal-coefficient-digit-range").toString();
+        String [] x = exp_range.split(",");
+        
+        WriteRandomIonValues.writeRandomDecimals(Integer.valueOf(optionsMap.get("<data_size>").toString()), optionsMap.get("<output_file>").toString(), format, exp_range, coeffi_digits);
+    }       
+}

--- a/src/com/amazon/ion/benchmark/GeneratorOptions.java
+++ b/src/com/amazon/ion/benchmark/GeneratorOptions.java
@@ -9,7 +9,6 @@ public class GeneratorOptions {
         String format = optionsMap.get("--format").toString().substring(1,optionsMap.get("--format").toString().length()-1);
         String exp_range = optionsMap.get("--decimal-exponent-range").toString() ;
         String coeffi_digits= optionsMap.get("--decimal-coefficient-digit-range").toString();
-        String [] x = exp_range.split(",");
         
         WriteRandomIonValues.writeRandomDecimals(Integer.valueOf(optionsMap.get("<data_size>").toString()), optionsMap.get("<output_file>").toString(), format, exp_range, coeffi_digits);
     }       

--- a/src/com/amazon/ion/benchmark/GeneratorOptions.java
+++ b/src/com/amazon/ion/benchmark/GeneratorOptions.java
@@ -2,14 +2,54 @@ package com.amazon.ion.benchmark;
 
 import java.util.Map;
 
+import com.amazon.ion.IonReader;
+import com.amazon.ion.system.IonReaderBuilder;
+
 public class GeneratorOptions {
         
-    public static void excuteGenerator(Map<String, Object> optionsMap) throws Exception {
-            
-        String format = optionsMap.get("--format").toString().substring(1,optionsMap.get("--format").toString().length()-1);
-        String exp_range = optionsMap.get("--decimal-exponent-range").toString() ;
-        String coeffi_digits= optionsMap.get("--decimal-coefficient-digit-range").toString();
-        
-        WriteRandomIonValues.writeRandomDecimals(Integer.valueOf(optionsMap.get("<data_size>").toString()), optionsMap.get("<output_file>").toString(), format, exp_range, coeffi_digits);
-    }       
+    public static void executeGenerator(Map<String, Object> optionsMap) throws Exception {
+        int size = Integer.valueOf(optionsMap.get("--data-size").toString());
+        String expRange = optionsMap.get("--decimal-exponent-range").toString();
+        String coefficientDigits = optionsMap.get("--decimal-coefficient-digit-range").toString();
+        String format = optionsMap.get("--format").toString().substring(1, optionsMap.get("--format").toString().length() - 1);
+        String path = optionsMap.get("<output_file>").toString();
+        String range = optionsMap.get("--text-code-point-range").toString();
+        String type = optionsMap.get("--data-type").toString();
+
+        String timestampTemplate;
+        if (optionsMap.get("--timestamps-template") == null) {
+            timestampTemplate = "random";
+        } else {
+            timestampTemplate = optionsMap.get("--timestamps-template").toString();
+        }
+
+        switch (type) {
+            case "timestamp":
+                WriteRandomIonValues.writeRandomTimestamps(Integer.valueOf(optionsMap.get("--data-size").toString()), optionsMap.get("<output_file>").toString(), timestampTemplate, format);
+                break;
+            case "string":
+                WriteRandomIonValues.writeRandomStrings(Integer.valueOf(optionsMap.get("--data-size").toString()), optionsMap.get("<output_file>").toString(), range, format);
+                break;
+            case "decimal":
+                WriteRandomIonValues.writeRandomDecimals(Integer.valueOf(optionsMap.get("--data-size").toString()), optionsMap.get("<output_file>").toString(), format, expRange, coefficientDigits);
+                break;
+            case "integer":
+                WriteRandomIonValues.writeRandomInts(size, format, path);
+                break;
+            case "float":
+                WriteRandomIonValues.writeRandomFloats(size, format, path);
+                break;
+            case "blob":
+                WriteRandomIonValues.writeRandomLobs(size, type, format, path);
+                break;
+            case "clob":
+                WriteRandomIonValues.writeRandomLobs(size, type, format, path);
+                break;
+            case "symbol":
+                WriteRandomIonValues.writeRandomSymbolValues(size, format, path);
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + type);
+        }
+    }
 }

--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -2,7 +2,6 @@ package com.amazon.ion.benchmark;
 
 import org.docopt.Docopt;
 
-import java.beans.beancontext.BeanContextServicesListener;
 import java.util.Map;
 
 public class Main {
@@ -43,7 +42,10 @@ public class Main {
             + "[--ion-use-lob-chunks <bool>]... [--ion-use-big-decimals <bool>]..."
             + "[--json-use-big-decimals <bool>]... <input_file>\n"
         
-        + "  ion-java-benchmark generate <size> <type> <file>\n" // generate command 
+        + "  ion-java-benchmark generate <data_size> <data_type> <output_file> [--format <type>] "
+            + "[--decimal-exponent-range <exp_range>] [--decimal-coefficient-digit-range <val_range>] "
+            + "[—text-code-point-range <range>] [—timestamp-precision <list>]\n"
+        
         + "  ion-java-benchmark --help\n"
 
         + "  ion-java-benchmark --version\n\n";
@@ -68,7 +70,9 @@ public class Main {
             + "DOM loader is included in each timed benchmark invocation. Therefore, it is important to provide "
             + "data that closely matches the size of data read by a single reader/loader instance in the real "
             + "world to ensure the initialization cost is properly amortized.\n"
-        + " generate\n"///
+        
+        + " generate\n"//TBD
+        
         + "\n";
 
     private static final String OPTIONS =
@@ -224,6 +228,12 @@ public class Main {
             + "stream (whichever is smaller). To avoid resizing, this value should be larger than the largest "
             + "top-level value in the Ion stream. Ignored unless --format ion_binary and --ion-reader incremental are "
             + "specified. May be specified multiple times to compare different settings.\n"
+        
+        // 'generate' options:TBD
+        
+        + "  -E --decimal-exponent-range <exp_range>      [default: -38,0]\n" 
+        
+        + "  -C --decimal-coefficient-digit-range <val_range>      [default: 1,9]\n"
 
         + "\n";
 
@@ -316,17 +326,12 @@ public class Main {
         if (optionsMap.get("--help").equals(true)) {
             printHelpAndExit();
         }
-       
         try {
         	 if (optionsMap.get("generate").equals(true)) {
-        		 try {
-        				WriteRandomIonValues.writeRandomDecimals(Integer.valueOf(optionsMap.get("<size>").toString()),optionsMap.get("<file>").toString());
-        			} catch (Exception e) {
-        				e.printStackTrace();
-        			}
+        		 GeneratorOptions.excuteGenerator(optionsMap);	
         	 }else {
-        		 OptionsMatrixBase options = OptionsMatrixBase.from(optionsMap);
-               options.executeBenchmark();
+        	     OptionsMatrixBase options = OptionsMatrixBase.from(optionsMap);
+        	     options.executeBenchmark();
 			}
         } catch (Exception e) {
             System.err.println(e.getMessage());

--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -42,9 +42,9 @@ public class Main {
             + "[--ion-use-lob-chunks <bool>]... [--ion-use-big-decimals <bool>]..."
             + "[--json-use-big-decimals <bool>]... <input_file>\n"
         
-        + "  ion-java-benchmark generate <data_size> <data_type> <output_file> [--format <type>] "
-            + "[--decimal-exponent-range <exp_range>] [--decimal-coefficient-digit-range <val_range>] "
-            + "[—text-code-point-range <range>] [—timestamp-precision <list>]\n"
+        + "  ion-java-benchmark generate (--data-size <data_size>) (--data-type <data_type>) "
+            + "[--format <type>] [--decimal-exponent-range <exp_range>] [--decimal-coefficient-digit-range <val_range>] "
+            + "[--timestamps-template <template>] [--text-code-point-range <range>] <output_file>\n"
         
         + "  ion-java-benchmark --help\n"
 
@@ -231,9 +231,17 @@ public class Main {
         
         // 'generate' options:TBD
         
-        + "  -E --decimal-exponent-range <exp_range>      [default: -38,0]\n" 
+        + "  -E --decimal-exponent-range <exp_range>      [default: [-32,0]]\n"
         
-        + "  -C --decimal-coefficient-digit-range <val_range>      [default: 1,9]\n"
+        + "  -C --decimal-coefficient-digit-range <val_range>      [default: [1,32]]\n"
+        
+        + "  -S --data-size <data_size>\n"
+        
+        + "  -T --data-type <data_type>\n"
+
+        + "  -M --timestamps-template <template>\n"
+
+        + "  -N --text-code-point-range <range>      [default: [0,1114111]]"
 
         + "\n";
 
@@ -328,7 +336,7 @@ public class Main {
         }
         try {
         	 if (optionsMap.get("generate").equals(true)) {
-        		 GeneratorOptions.excuteGenerator(optionsMap);	
+        	     GeneratorOptions.executeGenerator(optionsMap);
         	 }else {
         	     OptionsMatrixBase options = OptionsMatrixBase.from(optionsMap);
         	     options.executeBenchmark();

--- a/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
+++ b/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
@@ -497,8 +497,7 @@ abstract class OptionsMatrixBase {
         if (optionsMatrix.get("write").equals(true)) {
             matrix = new WriteOptionsMatrix(optionsMatrix);
         } else if (optionsMatrix.get("read").equals(true)) {
-            matrix = new ReadOptionsMatrix(optionsMatrix);
-           
+            matrix = new ReadOptionsMatrix(optionsMatrix);         
         } else {
             throw new IllegalArgumentException("Unknown command. Select from: write, read.");
         }

--- a/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
+++ b/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
@@ -497,8 +497,8 @@ abstract class OptionsMatrixBase {
         if (optionsMatrix.get("write").equals(true)) {
             matrix = new WriteOptionsMatrix(optionsMatrix);
         } else if (optionsMatrix.get("read").equals(true)) {
-            matrix = new ReadOptionsMatrix(optionsMatrix);         
-        } else {
+            matrix = new ReadOptionsMatrix(optionsMatrix);
+            } else {
             throw new IllegalArgumentException("Unknown command. Select from: write, read.");
         }
         return matrix;


### PR DESCRIPTION
This PR updated the generate command line format to:
ion-java-benchmark generate <data_size> <data_type> <output_file> [--format <type>] [--decimal-exponent-range <exp_range>] [--decimal-coefficient-digit-range <val_range>] [—text-code-point-range <range>] [—timestamp-precision <list>]

Added options which can specify the range:
-E --decimal-exponent-range <exp_range>
-C --decimal-coefficient-digit-range <val_range>
Note : these options are not required, and default value provided(TBD)

Methods need feedback:
Class WriteRandomIonValues:
Method 1 -- formatWriter: which can return the specified IonWriter based on the input format(ion_binary/ion_text)
Method 2 -- writeRandomDecimals: which can generate streams of random decimals based on provided exponent value range and coefficient digits range 

