### PR TITLE
Adds new features to Ion Data Generator to process constraints of Timestamp, Clob and Decimal.

### DIFF
--- a/src/com/amazon/ion/benchmark/GeneratorOptions.java
+++ b/src/com/amazon/ion/benchmark/GeneratorOptions.java
@@ -32,6 +32,7 @@ public class GeneratorOptions {
         }
         if (optionsMap.get("--input-ion-schema") != null) {
             String inputFilePath = optionsMap.get("--input-ion-schema").toString();
+            IonSchemaUtilities.checkValidationOfSchema(inputFilePath);
             ReadGeneralConstraints.readIonSchemaAndGenerate(size, inputFilePath, format, path);
         } else if (optionsMap.get("--data-type") != null) {
             IonType type = IonType.valueOf(optionsMap.get("--data-type").toString().toUpperCase());

--- a/src/com/amazon/ion/benchmark/GeneratorOptions.java
+++ b/src/com/amazon/ion/benchmark/GeneratorOptions.java
@@ -55,7 +55,7 @@ public class GeneratorOptions {
                     break;
                 case BLOB:
                 case CLOB:
-                    WriteRandomIonValues.writeRandomLobs(size, type, format, path);
+                    WriteRandomIonValues.writeRandomLobs(size, type, format, path, WriteRandomIonValues.NO_CONSTRAINT_STRUCT);
                     break;
                 case SYMBOL:
                     WriteRandomIonValues.writeRandomSymbolValues(size, format, path);

--- a/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
+++ b/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
@@ -32,8 +32,11 @@ public class IonSchemaUtilities {
     public static final String KEYWORD_ORDERED = "ordered";
     public static final String KEYWORD_NAME = "name";
     public static final String KEYWORD_CONTAINER_LENGTH = "container_length";
+    public static final String KEYWORD_BYTE_LENGTH = "byte_length";
     public static final String KEYWORD_MIN = "min";
     public static final String KEYWORD_MAX = "max";
+    public static final String KEYWORD_SCALE = "scale";
+    public static final String KEYWORD_PRECISION = "precision";
 
     /**
      * Extract the value of the constraints, select from the set (occurs | container_length | codepoint_length).
@@ -72,6 +75,8 @@ public class IonSchemaUtilities {
                             if (reader.getType() == IonType.SYMBOL) {
                                 if (reader.symbolValue().equals(KEYWORD_MIN)) {
                                     min = 0;
+                                } else if (keyWord.equals(IonSchemaUtilities.KEYWORD_TIMESTAMP_PRECISION)) {
+                                    min = Timestamp.Precision.valueOf(reader.stringValue().toUpperCase()).ordinal();
                                 } else {
                                     throw new IllegalStateException("The lower bound symbol value is not supported in Ion Schema");
                                 }
@@ -82,6 +87,8 @@ public class IonSchemaUtilities {
                             if (reader.getType() == IonType.SYMBOL) {
                                 if (reader.symbolValue().equals(KEYWORD_MAX)) {
                                     max = Integer.MAX_VALUE;
+                                } else if (keyWord.equals(IonSchemaUtilities.KEYWORD_TIMESTAMP_PRECISION)) {
+                                    max = Timestamp.Precision.valueOf(reader.stringValue().toUpperCase()).ordinal();
                                 } else {
                                     throw new IllegalStateException("The upper bound symbol value is not supported in Ion Schema");
                                 }

--- a/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
+++ b/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
@@ -39,7 +39,7 @@ public class IonSchemaUtilities {
     public static final String KEYWORD_PRECISION = "precision";
 
     /**
-     * Extract the value of the constraints, select from the set (occurs | container_length | codepoint_length).
+     * Extract the value of the constraints, select from the set (occurs | container_length | codepoint_length | timestamp_precision | precision | scale | byte_length).
      * @param value is the Ion struct which contain the current constraint field
      * @param keyWord is the field name of the constraint
      * @return the value of the current constraint.

--- a/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
+++ b/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
@@ -1,5 +1,6 @@
 package com.amazon.ion.benchmark;
 
+import com.amazon.ion.IonDatagram;
 import com.amazon.ion.IonList;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonStruct;
@@ -7,7 +8,12 @@ import com.amazon.ion.IonType;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.Timestamp;
 import com.amazon.ion.system.IonReaderBuilder;
+import com.amazon.ionschema.InvalidSchemaException;
+import com.amazon.ionschema.IonSchemaSystem;
+import com.amazon.ionschema.IonSchemaSystemBuilder;
 
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,6 +43,21 @@ public class IonSchemaUtilities {
     public static final String KEYWORD_MAX = "max";
     public static final String KEYWORD_SCALE = "scale";
     public static final String KEYWORD_PRECISION = "precision";
+
+    /**
+     * Check the validation of input ion schema file and will throw InvalidSchemaException message when an invalid schema definition is encountered.
+     * @param inputFile represents the file path of the ion schema file.
+     * @throws Exception if an error occur when creating FileInputStream.
+     */
+    public static void checkValidationOfSchema(String inputFile) throws Exception {
+        IonSchemaSystem ISS = IonSchemaSystemBuilder.standard().build();
+        try (IonReader readerInput = IonReaderBuilder.standard().build(new BufferedInputStream(new FileInputStream(inputFile)))) {
+            IonDatagram schema = ReadGeneralConstraints.LOADER.load(readerInput);
+            ISS.newSchema(schema.iterator());
+        } catch (InvalidSchemaException e) {
+            System.out.println(e.getMessage());
+        } throw new Exception("The provided ion schema file is not valid");
+    }
 
     /**
      * Extract the value of the constraints, select from the set (occurs | container_length | codepoint_length | timestamp_precision | precision | scale | byte_length).

--- a/src/com/amazon/ion/benchmark/ReadGeneralConstraints.java
+++ b/src/com/amazon/ion/benchmark/ReadGeneralConstraints.java
@@ -46,13 +46,14 @@ public class ReadGeneralConstraints {
                             WriteRandomIonValues.writeRandomStructValues(size, format, outputFile, constraintStruct);
                             break;
                         case TIMESTAMP:
-                            WriteRandomIonValues.writeRandomTimestamps(size, type, outputFile, null, format);
+                            WriteRandomIonValues.writeRandomTimestampsFromSchema(size, type, outputFile, format, constraintStruct);
                             break;
                         case STRING:
                             int codePointBoundary = IonSchemaUtilities.parseConstraints(constraintStruct, IonSchemaUtilities.KEYWORD_CODE_POINT_LENGTH);
                             WriteRandomIonValues.writeRandomStrings(size, type, outputFile, DEFAULT_RANGE, format, codePointBoundary);
                             break;
                         case DECIMAL:
+                            WriteRandomIonValues.writeRandomDecimalsFromSchema(size, type, outputFile, format, constraintStruct);
                             break;
                         case INT:
                             WriteRandomIonValues.writeRandomInts(size, type, format, outputFile);
@@ -62,7 +63,7 @@ public class ReadGeneralConstraints {
                             break;
                         case BLOB:
                         case CLOB:
-                            WriteRandomIonValues.writeRandomLobs(size, type, format, outputFile);
+                            WriteRandomIonValues.writeRandomLobs(size, type, format, outputFile, constraintStruct);
                             break;
                         case SYMBOL:
                             WriteRandomIonValues.writeRandomSymbolValues(size, format, outputFile);

--- a/src/com/amazon/ion/benchmark/WriteRandomIonValues.java
+++ b/src/com/amazon/ion/benchmark/WriteRandomIonValues.java
@@ -45,6 +45,7 @@ import java.util.Random;
  * Generate specific scalar type of Ion data randomly, for some specific type, e.g. String, Decimal, Timestamp, users can put specifications on these types of Ion data.
  */
 class WriteRandomIonValues {
+    // The constant defined below are used as placeholder in the method WriteRandomIonValues.writeRequestedSizeFile.
     final static private IonSystem SYSTEM = IonSystemBuilder.standard().build();
     final static private List<Integer> DEFAULT_RANGE = WriteRandomIonValues.parseRange("[0, 1114111]");
     final static private Timestamp.Precision[] PRECISIONS = Timestamp.Precision.values();
@@ -411,11 +412,12 @@ class WriteRandomIonValues {
     /**
      * Write random Ion blobs/clobs into target file, and all data conform with the specifications provided by the options, e.g. size, format, type(blob/clob) and the output file path.
      * @param size specifies the size in bytes of the generated file.
-     * @param path the destination of the generated file.
-     * @param format the format of output file (ion_binary | ion_text).
      * @param type determines which type of data will be generated [blob | clob].
+     * @param format the format of output file (ion_binary | ion_text).
+     * @param path the destination of the generated file.
+     * @param constraintStruct is an IonStruct which contains the top-level constraints in Ion Schema.
      * @throws Exception if an error occurs when building up the writer.
-    */
+     */
     public static void writeRandomLobs(int size, IonType type, String format, String path, IonStruct constraintStruct) throws Exception {
         File file = new File(path);
         Random random = new Random();
@@ -662,8 +664,9 @@ class WriteRandomIonValues {
     public static BigDecimal constructDecimalFromSchema(int precision, int scale) {
         Random random = new Random();
         StringBuilder rs = new StringBuilder();
-        for (int digit = 0; digit < precision; digit++) {
-            rs.append(random.nextInt(9) + 1);
+        rs.append(random.nextInt(9) + 1);
+        for (int digit = 1; digit < precision; digit++) {
+            rs.append(random.nextInt(10));
         }
         BigInteger unscaledValue = new BigInteger(rs.toString());
         BigDecimal bigDecimal = new BigDecimal(unscaledValue, scale);

--- a/src/com/amazon/ion/benchmark/WriteRandomIonValues.java
+++ b/src/com/amazon/ion/benchmark/WriteRandomIonValues.java
@@ -707,7 +707,7 @@ class WriteRandomIonValues {
      * @throws IOException if an error occurs during the writing process
      */
     public static void constructLobs(Random random, IonType type, IonWriter writer, int byte_length) throws IOException {
-        byte[] randomBytes = new byte[random.nextInt(512)];
+        byte[] randomBytes = new byte[byte_length];
         random.nextBytes(randomBytes);
         switch (type) {
             case CLOB:

--- a/src/com/amazon/ion/benchmark/WriteRandomIonValues.java
+++ b/src/com/amazon/ion/benchmark/WriteRandomIonValues.java
@@ -36,6 +36,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -52,7 +53,7 @@ class WriteRandomIonValues {
     final static private List<Integer> NO_EXPONENT_VALUE_RANGE = null;
     final static private List<Integer> NO_COEFFICIENT_DIGIT_RANGE = null;
     final static private String NO_TIMESTAMP_TEMPLATE = null;
-    final static private IonStruct NO_CONSTRAINT_STRUCT = null;
+    final static public IonStruct NO_CONSTRAINT_STRUCT = null;
 
     /**
      * Build up the writer based on the provided format (ion_text|ion_binary)
@@ -161,6 +162,23 @@ class WriteRandomIonValues {
     }
 
     /**
+     * Write random Ion decimals into the file, and all generated data is conformed with the constraints provided by Ion schema file.
+     * @param size specifies the size in bytes of the generated file.
+     * @param type determines which type of ion data will be generated.
+     * @param path the destination of the generated file.
+     * @param format the format of output file (ion_binary | ion_text).
+     * @param constraintStruct is an IonStruct which contains the top-level constraints in Ion Schema.
+     * @throws Exception if an error occurs when building up the writer.
+     **/
+    public static void writeRandomDecimalsFromSchema(int size, IonType type, String path, String format, IonStruct constraintStruct) throws Exception {
+        File file = new File(path);
+        try (IonWriter writer = WriteRandomIonValues.formatWriter(format, file)) {
+            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, NO_TIMESTAMP_TEMPLATE, constraintStruct);
+        }
+        WriteRandomIonValues.printInfo(path);
+    }
+
+    /**
      * Write random Ion integers into target file, and all data conform with the specifications provided by the options, e.g. size, format and the output file path.
      * @param size specifies the size in bytes of the generated file.
      * @param type determines which type of data will be generated.
@@ -249,7 +267,7 @@ class WriteRandomIonValues {
     /**
      * Generate random fractional second which the precision conforms with the precision of the second in template timestamp.
      * @param random is the random number generator.
-     * @param scale is the the scale of the decimal second in the current template timestamp.
+     * @param scale is the scale of the decimal second in the current template timestamp.
      * @return a random timestamp second in a fractional format which conforms with the current template timestamp.
      */
     private static BigDecimal randomSecondWithFraction(Random random, int scale) {
@@ -286,12 +304,29 @@ class WriteRandomIonValues {
     }
 
     /**
+     * Write random Ion timestamps into the file, and all generated data conforming with the constraints provided by Ion Schema file.
+     * @param size specifies the size in bytes of the generated file.
+     * @param type determines which type of data will be generated.
+     * @param path the destination of the generated file.
+     * @param format the format of output file (ion_binary | ion_text).
+     * @param constraintStruct is an IonStruct which contains the top-level constraints in Ion Schema.
+     * @throws Exception if an error occur when writing generated data.
+     */
+    public static void writeRandomTimestampsFromSchema (int size, IonType type,  String path, String format, IonStruct constraintStruct) throws Exception {
+        File file = new File(path);
+        try (IonWriter writer = WriteRandomIonValues.formatWriter(format, file)) {
+            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, NO_TIMESTAMP_TEMPLATE, constraintStruct);
+        }
+        WriteRandomIonValues.printInfo(path);
+    }
+
+    /**
      * Execute the writing timestamp data process based on the precision provided by the template timestamps.
      * @param precision is the precision of current template timestamp.
      * @param value is the current timestamp in the provided template.
      * @throws IOException if an error occurs when writing timestamp value.
      */
-    public static Timestamp writeTimestamp(Timestamp.Precision precision,  Timestamp value) throws IOException {
+    public static Timestamp writeTimestamp(Timestamp.Precision precision, Timestamp value) throws IOException {
         Timestamp timestamp;
         Random random = new Random();
         switch (precision) {
@@ -381,13 +416,19 @@ class WriteRandomIonValues {
      * @param type determines which type of data will be generated [blob | clob].
      * @throws Exception if an error occurs when building up the writer.
     */
-    public static void writeRandomLobs(int size, IonType type, String format, String path) throws Exception {
+    public static void writeRandomLobs(int size, IonType type, String format, String path, IonStruct constraintStruct) throws Exception {
         File file = new File(path);
+        Random random = new Random();
+        int byte_length;
+        if (constraintStruct != null) {
+            byte_length = IonSchemaUtilities.parseConstraints(constraintStruct, IonSchemaUtilities.KEYWORD_BYTE_LENGTH);
+        } else {
+            byte_length = random.nextInt(512);
+        }
         try (IonWriter writer = WriteRandomIonValues.formatWriter(format, file)) {
-            Random random = new Random();
             int currentSize = 0;
             while (currentSize <= size) {
-                WriteRandomIonValues.constructLobs(random, type, writer);
+                WriteRandomIonValues.constructLobs(random, type, writer, byte_length);
                 writer.flush();
                 currentSize = (int) file.length();
             }
@@ -485,7 +526,7 @@ class WriteRandomIonValues {
         Random random = new Random();
         int currentSize = 0;
         int count = 0;
-        // Determine how many values should be write before the writer.flush()
+        // Determine how many values should be written before the writer.flush()
         while (currentSize <= 0.05 * size) {
             WriteRandomIonValues.writeDataToFile(type, writer, random, codePointLength, pointRange, expValRange, coefficientDigitRange, timestampTemplate, constraintStruct);
             count += 1;
@@ -524,7 +565,13 @@ class WriteRandomIonValues {
                 writer.writeString(WriteRandomIonValues.constructString(pointRange, codePointLength));
                 break;
             case DECIMAL:
-                writer.writeDecimal(WriteRandomIonValues.constructDecimal(expValRange, coefficientDigitRange));
+                if (expValRange == null && coefficientDigitRange == null) {
+                    int decimalPrecision = IonSchemaUtilities.parseConstraints(constraintStruct, IonSchemaUtilities.KEYWORD_PRECISION);
+                    int decimalScale = IonSchemaUtilities.parseConstraints(constraintStruct, IonSchemaUtilities.KEYWORD_SCALE);
+                    writer.writeDecimal(WriteRandomIonValues.constructDecimalFromSchema(decimalPrecision, decimalScale));
+                } else {
+                    writer.writeDecimal(WriteRandomIonValues.constructDecimal(expValRange, coefficientDigitRange));
+                }
                 break;
             case INT:
                 long intValue = WriteRandomIonValues.constructInt();
@@ -549,7 +596,9 @@ class WriteRandomIonValues {
                         if (templateReader.next() != null) throw new IllegalStateException("Only one template list is needed");
                     }
                 } else {
-                    Timestamp timestamp = WriteRandomIonValues.constructTimestamp();
+                    int randomIndex = IonSchemaUtilities.parseConstraints(constraintStruct, IonSchemaUtilities.KEYWORD_TIMESTAMP_PRECISION);
+                    Timestamp.Precision precision = PRECISIONS[randomIndex];
+                    Timestamp timestamp = WriteRandomIonValues.constructTimestamp(precision);
                     writer.writeTimestamp(timestamp);
                 }
                 break;
@@ -605,6 +654,23 @@ class WriteRandomIonValues {
     }
 
     /**
+     * Construct the decimal which is conformed with the constraints provided in ISL.
+     * @param precision represents the minimum/maximum range indicating the number of digits in the unscaled value of a decimal. The minimum precision must be greater than or equal to 1.
+     * @param scale represents the minimum/maximum range indicating the number of digits to the right of the decimal point. The minimum scale must be greater than or equal to 0.
+     * @return the constructed decimal.
+     */
+    public static BigDecimal constructDecimalFromSchema(int precision, int scale) {
+        Random random = new Random();
+        StringBuilder rs = new StringBuilder();
+        for (int digit = 0; digit < precision; digit++) {
+            rs.append(random.nextInt(9) + 1);
+        }
+        BigInteger unscaledValue = new BigInteger(rs.toString());
+        BigDecimal bigDecimal = new BigDecimal(unscaledValue, scale);
+        return bigDecimal;
+    }
+
+    /**
      * Generate random integers which composed by different length of data into the output file.
      */
     public static long constructInt() {
@@ -628,10 +694,8 @@ class WriteRandomIonValues {
      * Construct output timestamps with random precision.
      * @throws IOException if an error occurs when writing timestamps.
      */
-    public static Timestamp constructTimestamp() throws IOException {
-        Random random = new Random();
-        Timestamp.Precision precision = PRECISIONS[random.nextInt(PRECISIONS.length)];
-        Timestamp timestamp = WriteRandomIonValues.writeTimestamp(precision, null);
+    public static Timestamp constructTimestamp(Timestamp.Precision timestampPrecision) throws IOException {
+        Timestamp timestamp = WriteRandomIonValues.writeTimestamp(timestampPrecision, null);
         return timestamp;
     }
 
@@ -642,7 +706,7 @@ class WriteRandomIonValues {
      * @param writer writes Ion clob/blob data.
      * @throws IOException if an error occurs during the writing process
      */
-    public static void constructLobs(Random random, IonType type, IonWriter writer) throws IOException {
+    public static void constructLobs(Random random, IonType type, IonWriter writer, int byte_length) throws IOException {
         byte[] randomBytes = new byte[random.nextInt(512)];
         random.nextBytes(randomBytes);
         switch (type) {

--- a/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
+++ b/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
@@ -52,6 +52,8 @@ public class DataGeneratorTest {
     private final static String INPUT_ION_STRUCT_FILE_PATH = "./tst/com/amazon/ion/benchmark/testStruct.isl";
     private final static String INPUT_ION_LIST_FILE_PATH = "./tst/com/amazon/ion/benchmark/testList.isl";
     private final static String INPUT_NESTED_ION_STRUCT_PATH = "./tst/com/amazon/ion/benchmark/testNestedStruct.isl";
+    private final static String INPUT_ION_DECIMAL_FILE_PATH = "./tst/com/amazon/ion/benchmark/testDecimal.isl";
+    private final static String INPUT_ION_TIMESTAMP_FILE_PATH = "./tst/com/amazon/ion/benchmark/testTimestamp.isl";
     private final static String SCORE_DIFFERENCE = "scoreDifference";
     private final static String COMPARISON_REPORT_WITHOUT_REGRESSION = "./tst/com/amazon/ion/benchmark/testComparisonReportWithoutRegression.ion";
     private final static String COMPARISON_REPORT = "./tst/com/amazon/ion/benchmark/testComparisonReport.ion";
@@ -102,7 +104,7 @@ public class DataGeneratorTest {
                     break;
                 }
             }
-            // Construct new schema amd get the type of the Ion Schema.
+            // Construct new schema and get the type of the Ion Schema.
             Schema newSchema = ISS.newSchema(schema.iterator());
             Type type = newSchema.getType(ionSchemaName);
             while (reader.next() != null) {
@@ -286,6 +288,24 @@ public class DataGeneratorTest {
     @Test
     public void testViolationOfNestedIonStruct() throws Exception {
         DataGeneratorTest.violationDetect(INPUT_NESTED_ION_STRUCT_PATH);
+    }
+
+    /**
+     * Test if there's violation when generating Ion Timestamp based on Ion Schema.
+     * @throws Exception  if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testViolationOfTimestamp() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_ION_TIMESTAMP_FILE_PATH);
+    }
+
+    /**
+     * Test if there's violation when generating decimals based on Ion Schema.
+     * @throws Exception if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testViolationOfIonDecimal() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_ION_DECIMAL_FILE_PATH);
     }
 
     /**

--- a/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
+++ b/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
@@ -55,6 +55,7 @@ public class DataGeneratorTest {
     private final static String INPUT_ION_DECIMAL_FILE_PATH = "./tst/com/amazon/ion/benchmark/testDecimal.isl";
     private final static String INPUT_ION_TIMESTAMP_FILE_PATH = "./tst/com/amazon/ion/benchmark/testTimestamp.isl";
     private final static String INPUT_ION_CLOB_FILE_PATH = "./tst/com/amazon/ion/benchmark/testClob.isl";
+    private final static String INPUT_ION_BLOB_FILE_PATH = "./tst/com/amazon/ion/benchmark/testBlob.isl";
     private final static String SCORE_DIFFERENCE = "scoreDifference";
     private final static String COMPARISON_REPORT_WITHOUT_REGRESSION = "./tst/com/amazon/ion/benchmark/testComparisonReportWithoutRegression.ion";
     private final static String COMPARISON_REPORT = "./tst/com/amazon/ion/benchmark/testComparisonReport.ion";
@@ -293,7 +294,7 @@ public class DataGeneratorTest {
 
     /**
      * Test if there's violation when generating Ion Timestamp based on Ion Schema.
-     * @throws Exception  if error occurs during the violation detecting process.
+     * @throws Exception if error occurs during the violation detecting process.
      */
     @Test
     public void testViolationOfTimestamp() throws Exception {
@@ -316,6 +317,15 @@ public class DataGeneratorTest {
     @Test
     public void testViolationOfIonClob() throws Exception {
         DataGeneratorTest.violationDetect(INPUT_ION_CLOB_FILE_PATH);
+    }
+
+    /**
+     * Test if there's violation when generating blobs based on Ion Schema.
+     * @throws Exception if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testViolationOfIonBlob() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_ION_BLOB_FILE_PATH);
     }
 
     /**

--- a/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
+++ b/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
@@ -54,6 +54,7 @@ public class DataGeneratorTest {
     private final static String INPUT_NESTED_ION_STRUCT_PATH = "./tst/com/amazon/ion/benchmark/testNestedStruct.isl";
     private final static String INPUT_ION_DECIMAL_FILE_PATH = "./tst/com/amazon/ion/benchmark/testDecimal.isl";
     private final static String INPUT_ION_TIMESTAMP_FILE_PATH = "./tst/com/amazon/ion/benchmark/testTimestamp.isl";
+    private final static String INPUT_ION_CLOB_FILE_PATH = "./tst/com/amazon/ion/benchmark/testClob.isl";
     private final static String SCORE_DIFFERENCE = "scoreDifference";
     private final static String COMPARISON_REPORT_WITHOUT_REGRESSION = "./tst/com/amazon/ion/benchmark/testComparisonReportWithoutRegression.ion";
     private final static String COMPARISON_REPORT = "./tst/com/amazon/ion/benchmark/testComparisonReport.ion";
@@ -306,6 +307,15 @@ public class DataGeneratorTest {
     @Test
     public void testViolationOfIonDecimal() throws Exception {
         DataGeneratorTest.violationDetect(INPUT_ION_DECIMAL_FILE_PATH);
+    }
+
+    /**
+     * Test if there's violation when generating clobs based on Ion Schema.
+     * @throws Exception if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testViolationOfIonClob() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_ION_CLOB_FILE_PATH);
     }
 
     /**

--- a/tst/com/amazon/ion/benchmark/testBlob.isl
+++ b/tst/com/amazon/ion/benchmark/testBlob.isl
@@ -1,0 +1,9 @@
+schema_header::{
+}
+type::{
+    name: Blob,
+    type: blob,
+    byte_length: range::[10, 100],
+}
+schema_footer::{
+}

--- a/tst/com/amazon/ion/benchmark/testClob.isl
+++ b/tst/com/amazon/ion/benchmark/testClob.isl
@@ -1,0 +1,9 @@
+schema_header::{
+}
+type::{
+    name: Clob,
+    type: clob,
+    byte_length: range::[2, 100],
+}
+schema_footer::{
+}

--- a/tst/com/amazon/ion/benchmark/testDecimal.isl
+++ b/tst/com/amazon/ion/benchmark/testDecimal.isl
@@ -1,0 +1,10 @@
+schema_header::{
+}
+type::{
+    name: Decimal,
+    type: decimal,
+    precision: range::[5, 9],
+    scale: 2,
+}
+schema_footer::{
+}

--- a/tst/com/amazon/ion/benchmark/testTimestamp.isl
+++ b/tst/com/amazon/ion/benchmark/testTimestamp.isl
@@ -1,0 +1,9 @@
+schema_header::{
+}
+type::{
+    name: Timestamp,
+    type: timestamp,
+    timestamp_precision: range::[year, day],
+}
+schema_footer::{
+}


### PR DESCRIPTION
**Description of changes:**
In this pull request, more features were added to support Ion Data Generator to process more constraints provided by Ion Schema. The supported Ion Schema constraints in this PR includes:

- Timestamp:
```
   timestamp_precision:<RANGE<TIMESTAMP_PRECISION_VALUE>>
```
- Decimal:
```
   precision: <INT>
   precision: <RANGE<INT>>
   scale: <INT>
   scale: <RANGE<INT>>
 ```
- Clob:
 ```
   byte_length: <INT>
   byte_length: <RANGE<INT>>
 ```

1. IonSchedmaUtilities.java

- Adds logic to process timestamp_precision:<RANGE<TIMESTAMP_PRECISION_VALUE>> to the method `IonSchemaUtilities.parseConstraints`.

2. WriteRandomIonValues.java

- Adds method `WriteRandomIonValues.writeRandomDecimalsFromSchema` which is able to process the constraints of decimal.
- Adds method `WriteRandomIonValues.writeRandomTimestampsFromSchema` which is able to process the constraints of timestamp.
- Adds parameter constraintStruct to method `WriteRandomIonValues.writeRandomLobs` to allow the method to process the constraints of clob.
- Add method `WriteRandomIonValues.constructDecimalFromSchema` which is able to construct the decimal conforming with the constraints in Ion Schema.

**Test:**
- Adds two ISL file (testTimestamp.isl, testDecimal.isl) as inputs to test the Ion Data generator .
- Adds methods to test whether there is violation when generating timestamps , clobs and decimals.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.